### PR TITLE
Switch order of equality & condition expectations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - `PhyDatToMatrix()` optionally encodes ambiguous / inapplicable tokens as `NA`.
 
+- Update test suite for compatibility with "testthat" > 3.0.4 (@hadley, #83).
+
 # TreeTools 1.5.0
 
 

--- a/tests/testthat/test-ImposeConstraint.R
+++ b/tests/testthat/test-ImposeConstraint.R
@@ -27,8 +27,9 @@ test_that("ImposeConstraint() works", {
     c(0, 0, '?', '?', 1, 1,
       1, 1,   1, '?', 0, 0), ncol = 2,
     dimnames = list(letters[1:6], NULL)))
-  expect_true(inherits(expect_warning(
-    ImposeConstraint(NJTree(constraint), constraint)), 'phylo'))
+
+  expect_warning(out <- ImposeConstraint(NJTree(constraint), constraint))
+  expect_true(inherits(out, 'phylo'))
 
   # Need to collapse splits intelligently to avoid error.  From Joe Moysiuk.
   constraint <- MatrixToPhyDat(

--- a/tests/testthat/test-consensus.R
+++ b/tests/testthat/test-consensus.R
@@ -5,9 +5,10 @@ test_that("Consensus() errors", {
   expect_equal(oneLeaf$Nnode, 0)
   expect_identical(Consensus(list(DropTip(bal8, 1:8))[c(1, 1, 1)]),
                    DropTip(bal8, 1:8))
-  expect_true(all.equal(
-    expect_warning(Consensus(list(PectinateTree(6), PectinateTree(8)))),
-    PectinateTree(6)))
+  expect_warning(expect_true(all.equal(
+    Consensus(list(PectinateTree(6), PectinateTree(8))),
+    PectinateTree(6)
+  )))
 
   halfTree <- CollapseNode(bal8, 10:12)
   expect_equal(Consensus(halfTree), halfTree)

--- a/tests/testthat/test-tree_rearrange.R
+++ b/tests/testthat/test-tree_rearrange.R
@@ -289,12 +289,15 @@ test_that("DropTip() works", {
 })
 
 test_that("KeepTip() works", {
-  expect_true(all.equal(
+  expect_warning(expect_true(all.equal(
     BalancedTree(paste0('t', 5:8)),
-    expect_warning(KeepTip(BalancedTree(8), paste0('t', 5:9)))
-  ))
-  expect_true(all.equal(BalancedTree(paste0('t', 5:8)),
-                        expect_warning(KeepTip(BalancedTree(8), 5:9))))
+    KeepTip(BalancedTree(8), paste0('t', 5:9))
+  )))
+
+  expect_warning(expect_true(all.equal(
+    BalancedTree(paste0('t', 5:8)),
+    KeepTip(BalancedTree(8), 5:9)
+  )))
 })
 
 test_that("Binarification is uniform", {


### PR DESCRIPTION
In the dev version of testthat, we've tweaked `expect_warning()` and friends to return output that's [more consistent](https://github.com/r-lib/testthat/blob/master/NEWS.md#breaking-changes) with other testthat expectations. We'd like to get testthat on to CRAN in the near future, so I'd really appreciate it if you could merge this change and update your package on CRAN.