### PR TITLE
Root tree on random edge

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TreeTools
 Title: Create, Modify and Analyse Phylogenetic Trees
-Version: 1.10.0.9004
+Version: 1.10.0.9005
 Authors@R: c(
   person("Martin R.", 'Smith', role = c("aut", "cre", "cph"), 
          email = "martin.smith@durham.ac.uk",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# TreeTools 1.10.0.9004 (development) #
+# TreeTools 1.10.0.9005 (development) #
 
 ## New methods and functions
 
@@ -9,6 +9,7 @@
 
 ## Enhancements
 
+- `RandomTree(root = TRUE)` roots the tree on a random edge.
 - `RoguePlot()$legendLabels` returns suggested labels for legend.
 - Support node labels in `AddTip()`, `CollapseNode()`, `DropTip()`, 
   `MakeTreeBinary()`, `Renumber()`, `Reorder()`, `SortTree()`, `Subtree()`

--- a/R/tree_generation.R
+++ b/R/tree_generation.R
@@ -17,13 +17,11 @@
 #' @name GenerateTree
 NULL
 
-# Until require R >= 3.5.0
-.isFALSE <- function(x) is.logical(x) && length(x) == 1L && !is.na(x) && !x
-
 #' @rdname GenerateTree
 #'
-#' @param root Character or integer specifying tip to use as root, if desired;
-#' or `FALSE` for an unrooted tree.
+#' @param root Character or integer specifying tip to use as root;
+#' or `TRUE` to root the tree on a random edge;
+#' or `FALSE` to return an unrooted tree.
 #' @param nodes Number of nodes to generate.  The default and maximum,
 #' `tips - 1`, generates a binary tree; setting a lower value will induce
 #' polytomies.
@@ -88,8 +86,12 @@ RandomTree <- function(tips, root = FALSE, nodes) {
                          br = NULL),
                     class = "phylo")
 
-  if (.isFALSE(root)) {
-    tree <- UnrootTree(tree)
+  if (is.logical(root)) {
+    if (root[[1]]) {
+      tree <- root_on_node(tree, sample.int(nTips + nodes, 1))
+    } else {
+      tree <- UnrootTree(tree)
+    }
   }
 
   if (nodes < nodesInBinary) {

--- a/tests/testthat/test-TotalCopheneticIndex.R
+++ b/tests/testthat/test-TotalCopheneticIndex.R
@@ -30,3 +30,26 @@ test_that("Trees from Mir et al. 2013 are scored correctly", {
 
   expect_equal(TCIContext(BalancedTree(5)), TCIContext(5L))
 })
+
+test_that("Expectations are correct", {
+  nTip <- 5
+  uniform <- DropTip(
+    unlist(recursive = FALSE,
+           lapply(
+             lapply(as.phylo(1:NUnrooted(nTip) - 1, nTip),
+                    AddTipEverywhere, "ROOT"),
+             RootTree, "ROOT")
+           ),
+    "ROOT")
+  tci <- TotalCopheneticIndex(uniform)
+  context <- TCIContext(nTip)
+  expect_equal(range(tci), range(context[1:2]))
+  expect_equal(mean(tci), context[["uniform.expected"]])
+  
+  unif <- replicate(100, TotalCopheneticIndex(RandomTree(10, root = TRUE)))
+  expect_equal(
+    mean(unif),
+    TCIContext(10)$uniform.expected, # 76
+    tolerance = 0.05
+  )
+})


### PR DESCRIPTION
Resolves #145 

Trees were previously rooted on tip 1 (`TRUE` coerced to `1`)