### PR TITLE
ci: revert ASAN runner to ubuntu-latest (r-hub gcc-asan has no arm64 image)

### DIFF
--- a/.github/workflows/ASan.yml
+++ b/.github/workflows/ASan.yml
@@ -27,7 +27,7 @@ name: gcc-ASAN
 
 jobs:
   mem-check:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/r-hub/containers/gcc-asan:latest
 


### PR DESCRIPTION
## Problem

The `gcc-ASAN` workflow has failed on every run since 2026-06-19. The
`2026-06-19` switch `ubuntu-latest` → `ubuntu-24.04-arm` (commit 01c99be9)
broke it: the `ghcr.io/r-hub/containers/gcc-asan:latest` image has **no
arm64 variant**, so the container dies at initialisation (~35s,
"container ... is not running") before any ASAN work runs.

## Fix

Revert the runner to `ubuntu-latest` (x86) — the exact config that ran
**green for 42 min on 2026-06-16** (commit decfe3e9). One-line change.

## Verification

Branch run [28646552710](https://github.com/ms609/TreeTools/actions/runs/28646552710)
completed **green** across all three legs (tests/examples/vignettes) in
17m — real ASAN execution restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)