### PR TITLE
RoguePlot(): guard preorder assertion against missing "order" attribute

### DIFF
--- a/R/RoguePlot.R
+++ b/R/RoguePlot.R
@@ -207,7 +207,7 @@ RoguePlot <- function(trees, tip, p = 1, plot = TRUE,
   if (isTRUE(sort)) {
     cons <- DropTip(cons, dummyRoot, preorder = FALSE, check = FALSE)
   } else {
-    stopifnot(attr(cons, "order") == "preorder")
+    stopifnot(identical(attr(cons, "order"), "preorder"))
     # We promise to return `cons` in preorder
     cons <- DropTip(cons, dummyRoot, preorder = TRUE, check = FALSE)
   }

--- a/tests/testthat/test-RoguePlot.R
+++ b/tests/testthat/test-RoguePlot.R
@@ -75,6 +75,20 @@ test_that("RoguePlot(sort = TRUE)", {
   expect_equal(sorted$atNode, unsorted$atNode)
 })
 
+test_that("RoguePlot() errors cleanly if cons loses its preorder attribute", {
+  trees <- list(read.tree(text = "(a, (b, (c, (rogue, (d, e)))));"),
+                read.tree(text = "(a, (b, (c, ((d, e), rogue))));"))
+  local_mocked_bindings(
+    Preorder = function(tree, ...) {
+      attr(tree, "order") <- NULL
+      tree
+    },
+    .package = "TreeTools"
+  )
+  expect_error(RoguePlot(trees, tip = "rogue", plot = FALSE),
+               "preorder")
+})
+
 test_that("polytomy id", {
   trees <- list(read.tree(text = "(a,(((b,(c,d)),e),rogue));"),
                 read.tree(text = "(a,((((c,d),e),rogue),b));"),

--- a/tests/testthat/test-RoguePlot.R
+++ b/tests/testthat/test-RoguePlot.R
@@ -76,6 +76,7 @@ test_that("RoguePlot(sort = TRUE)", {
 })
 
 test_that("RoguePlot() errors cleanly if cons loses its preorder attribute", {
+  skip_if_not_installed("testthat", "3.1.7") # for local_mocked_bindings()
   trees <- list(read.tree(text = "(a, (b, (c, (rogue, (d, e)))));"),
                 read.tree(text = "(a, (b, (c, ((d, e), rogue))));"))
   local_mocked_bindings(


### PR DESCRIPTION
## Summary
- `attr(cons, "order") == "preorder"` in `RoguePlot()` evaluates to `logical(0)` when the consensus tree lacks an `"order"` attribute, so `stopifnot()` passed vacuously instead of catching a non-preorder tree — a silent correctness no-op rather than a crash.
- Sibling instance to the crash-causing case already fixed in `RenumberTips.phylo` (a5ef0a00).
- Fixed by switching to `identical(attr(cons, "order"), "preorder")`, which correctly fails when the attribute is absent.
- Traced that `cons` is unconditionally `Preorder()`'d just before this check and nothing in between reassigns it, so the assertion (not a `Preorder()` call) is the right fix — the invariant should always hold, and the guard exists to catch it if it doesn't.
- Swept the rest of `R/` for unguarded `attr(x, "order") ==` comparisons; all other sites are already null-guarded.
- Added a regression test (mocking `Preorder()` to strip the attribute) confirming `RoguePlot()` now errors cleanly instead of silently passing.

## Test plan
- [x] `testthat::test_file("tests/testthat/test-RoguePlot.R")` — 25/25 pass (including new regression test)
- [x] Confirmed old `==` pattern passes vacuously on attr-less input; new `identical()` pattern correctly errors