### PR TITLE
ci: don't request -mcmodel=large on aarch64

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -166,11 +166,19 @@ jobs:
         if: runner.os == 'Linux' && (matrix.config.r == '4.0' || matrix.config.r == 'devel')
         run: |
           mkdir -p ~/.R
-          echo "CXXFLAGS += -mcmodel=large" >> ~/.R/Makevars
-          echo "CXX11FLAGS += -mcmodel=large" >> ~/.R/Makevars
-          echo "CXX14FLAGS += -mcmodel=large" >> ~/.R/Makevars
-          echo "CXX17FLAGS += -mcmodel=large" >> ~/.R/Makevars
-          echo "PKG_LIBS += -mcmodel=large" >> ~/.R/Makevars
+
+          # ~/.R/Makevars applies to *every* package compiled on the runner,
+          # dependencies included.  aarch64 gcc implements no large code model
+          # compatible with -fPIC ("sorry, unimplemented: code model 'large'
+          # with '-fPIC'"), so asking for one there breaks the build of any
+          # package compiled from source.  Restrict the request to x86_64.
+          if [[ "$(uname -m)" == "x86_64" ]]; then
+            echo "CXXFLAGS += -mcmodel=large" >> ~/.R/Makevars
+            echo "CXX11FLAGS += -mcmodel=large" >> ~/.R/Makevars
+            echo "CXX14FLAGS += -mcmodel=large" >> ~/.R/Makevars
+            echo "CXX17FLAGS += -mcmodel=large" >> ~/.R/Makevars
+            echo "PKG_LIBS += -mcmodel=large" >> ~/.R/Makevars
+          fi
 
           # Maintain R 4.0 specific standard overrides
           if [[ "${{ matrix.config.r }}" == "4.0" ]]; then


### PR DESCRIPTION
## Diagnosis

`ubuntu-24.04-arm (devel)` is the only R-CMD-check job failing, and it has failed
every run since [0c5eee98](https://github.com/ms609/TreeTools/commit/0c5eee98) (2026-06-19)
moved the R-devel job from `ubuntu-24.04` to `ubuntu-24.04-arm`.

The failure is in pak's dependency install, not in TreeTools:

```
cc1plus: sorry, unimplemented: code model 'large' with '-fPIC'
ERROR: compilation failed for package 'digest'
```

[b80f4676](https://github.com/ms609/TreeTools/commit/b80f4676) (2026-04-22) added
`-mcmodel=large` to `~/.R/Makevars` for the Linux R 4.0 and R-devel jobs — both
x86_64 at the time. x86_64 gcc supports the large code model with `-fPIC`;
aarch64 gcc does not implement that combination at all, so the flag breaks
every package compiled from source on the arm runner. `digest` is just the first
one pak reaches.

Timeline:

| date | event |
|---|---|
| 2026-04-22 | `-mcmodel=large` added; devel job is x86_64, so it works |
| 2026-06-19 | devel job moved to `ubuntu-24.04-arm` |
| 2026-06-19 → | every scheduled run fails at dependency install |

## Fix

Guard the five `-mcmodel=large` lines on `uname -m == x86_64`. The x86_64 R 4.0
job — the only remaining consumer — is byte-identical.

## Notes for later

* The flag's purpose is undocumented, and `check-release` (ubuntu-24.04, x86_64)
  passes without ever running this step, so `-mcmodel=large` is not load-bearing
  for TreeTools on x86_64 Linux at R release. Dropping it outright is plausible
  but deserves a deliberate test rather than being folded in here: the R 4.0 job
  builds far more packages from a 2022 RSPM snapshot than `check-release` does.
* `~/.R/Makevars` applies to *every* package compiled on the runner, which is why
  this surfaced in a dependency. If the flag is ever genuinely needed by
  TreeTools itself, `src/Makevars` is its home.
* Nothing downstream of the dependency install has run on aarch64 + R-devel for
  eight weeks, so this may uncover a second, unrelated failure in that job. The
  PR run will tell us.

No `NEWS.md` / `DESCRIPTION` change: CI-only, not user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

*Agent work filed under @ms609's account because the `ms609-agent` account is
suspended (`HTTP 403: Your account was suspended`); the commit itself is
authored by `ms609-agent`. Note that GitHub will not let `ms609` approve an
`ms609`-authored PR, so this one needs a deliberate read rather than a review
approval.*
